### PR TITLE
Orm sql persistent session

### DIFF
--- a/lf/system/lib/orm.php
+++ b/lf/system/lib/orm.php
@@ -104,8 +104,8 @@ class orm {
 		if($this->debug)
 			echo $this->sql;
 	
-		if($this->mysqli)
-			$this->mysqli->close();
+		/*if($this->mysqli)
+			$this->mysqli->close();*/
 	}
 	
 	/**
@@ -113,10 +113,13 @@ class orm {
 	 */
 	public function initDb()
 	{
+		// leave mysqli object in session, but close it once the script finishes
 		/*if(isset($_SESSION['db']))
 		{
+			pre($_SESSION['db'], 'var_dump');
+			
 			$this->mysqli = $_SESSION['db'];
-			return $_SESSION['db'];
+			return $this;
 		}*/
 		
 		// check to make sure configuration file is there

--- a/lf/system/lib/orm.php
+++ b/lf/system/lib/orm.php
@@ -89,8 +89,7 @@ class orm {
 	 */
 	public function __construct($table = '', $db = NULL)
 	{
-		//if(is_null($db))
-			$this->initDb();
+		$this->initDb();
 		
 		if($table != '')
 			$this->table = $table;
@@ -103,9 +102,6 @@ class orm {
 	{
 		if($this->debug)
 			echo $this->sql;
-	
-		/*if($this->mysqli)
-			$this->mysqli->close();*/
 	}
 	
 	/**
@@ -113,14 +109,12 @@ class orm {
 	 */
 	public function initDb()
 	{
-		// leave mysqli object in session, but close it once the script finishes
-		/*if(isset($_SESSION['db']))
+		// leave mysqli object in session, but close it once the script finishes via ___LastSay
+		if(isset($_SESSION['db']))
 		{
-			pre($_SESSION['db'], 'var_dump');
-			
 			$this->mysqli = $_SESSION['db'];
 			return $this;
-		}*/
+		}
 		
 		// check to make sure configuration file is there
 		// config.php contains database credentials
@@ -908,6 +902,21 @@ class orm {
 
 //backward compatible
 class db extends orm {}
+
+// My nasty solution to ensuring $_SESSION['db'] is cleared
+// while allowing the orm class to use it without 
+class ___LastSay 
+{ 
+	public function __destruct()
+	{ 
+		if(isset($_SESSION['db']))
+		{
+			$_SESSION['db']->close();
+			unset($_SESSION['db']);
+		}
+	}
+}
+$varNameDoesntMatterSoLongAsItDestructsAfterTheScriptEnds = new ___LastSay();
 
 /**
  * If the class is not already defined, you can instantiate a new class through autoload. 


### PR DESCRIPTION
Finally found a good way to handle the persistent database connection in the session, but more importantly, a way to close it after the script finishes executing. I am sure there is a nicer way to do this, but I couldn't think of a way to let the orm be called as `new orm` from multiple contexts while keeping efficiency
