### PR TITLE
Installer2

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,8 @@
 <?php
 
 require_once('lf/system/bootstrap.php');	// Bootstrap the littlefoot PHP suite.
+
+
 $cms = new \lf\cms(); 						// Could have just done (new \lf\cms)->run();,
 $cms->run();								// but I like to be able to catch if you are `PHP 5.3`.
 

--- a/lf/config-dist.php
+++ b/lf/config-dist.php
@@ -4,8 +4,5 @@ $db['host'] = 'localhost';
 $db['user'] = 'mysql_user';
 $db['pass'] = 'mysql_passwd';
 $db['name'] = 'mysql_database';
-$db['prefix'] = 'lf_';
 
 $debug = false;
-
-?>

--- a/lf/system/lib/cms.php
+++ b/lf/system/lib/cms.php
@@ -288,10 +288,7 @@ class cms
 	 * load CMS settings into session from `lf_settings`
 	 */
 	public function loadSettings()
-	{
-		lfbacktrace();
-		exit;
-		
+	{	
 		(new plugin)->run('pre settings');
 		
 		foreach( (new \LfSettings)->getAll() as $setting )

--- a/lf/system/lib/cms.php
+++ b/lf/system/lib/cms.php
@@ -289,6 +289,9 @@ class cms
 	 */
 	public function loadSettings()
 	{
+		lfbacktrace();
+		exit;
+		
 		(new plugin)->run('pre settings');
 		
 		foreach( (new \LfSettings)->getAll() as $setting )
@@ -420,6 +423,21 @@ class cms
 		$appPlugin->run('post app');
 		
 		return ob_get_clean();
+	}
+	
+	/**
+	 * fun note: getSetting was causing a loop when the orm installer tried to ask request for the LF URL. so I moved it into CMS. now request has no ties to ORM
+	 * 
+	 * 
+	 * 
+	 **/
+	public function handleUrlRewrite()
+	{
+		// Add in 302 to fix rewrite and prevent duplicate content
+		if(getSetting('rewrite') == 'on' && requestGet('Index') == 'index.php/') 
+			redirect302( (new request)->load()->rewriteOn()->getActionUrl() );
+		else if(requestGet('Index') == '')
+			redirect302( (new request)->load()->rewriteOff()->getActionUrl() );
 	}
 	
 	/** 

--- a/lf/system/lib/cms.php
+++ b/lf/system/lib/cms.php
@@ -165,7 +165,7 @@ class cms
 		(new cache)->startTimer(__METHOD__);
 		
 		// test the installation. can we connect to MySQL, etc?
-		(new install)->test();
+		//(new install)->test();
 		
 		// initialize request into session. 
 		// this can technically be done JIT with `->load()`, 

--- a/lf/system/lib/helpers.php
+++ b/lf/system/lib/helpers.php
@@ -231,6 +231,7 @@ function lfbacktrace()
 {
 	$bt = debug_backtrace(); 
 
+	echo "<table cellspacing='5'>";
 	foreach($bt as $t)
 	{
 		$class = '';
@@ -244,9 +245,12 @@ function lfbacktrace()
 			$args = substr($args, 0, -2);
 		}
 		
+		echo '<tr>';
 		if(isset($t['file']))
-			echo '<br />'.$t['file'].' line '.$t['line'].' '.$class.$t['function'].'('.$args.')';
+			echo '<td>line '.$t['line'].' </td><td>'.$t['file'].' </td><td>'.$class.$t['function'].'('.$args.')</td>';
+		echo '</tr>';
 	}
+	echo "</table>";
 }
 
 /**

--- a/lf/system/lib/install.php
+++ b/lf/system/lib/install.php
@@ -10,7 +10,7 @@ if(!extension_loaded('mysqli'))
 }
 
 /**
- * @ignore
+ * provide installform
  */
 class install
 {
@@ -33,10 +33,7 @@ class install
 	
 	public function noconfig()
 	{
-		if(count($_POST) > 0)
-			$this->post();
 		
-		$msg = 'No configuration file found at lf/config.php (ignore this if installing for the first time)';
 		include LF.'system/lib/recovery/install.form.php';
 		
 		exit();
@@ -45,7 +42,7 @@ class install
 	// we tried to db, but couldn't... so nodb
 	private function nodb()
 	{
-		$this->errors[] = 'Unable to query database.';
+		notice('<div class="error">Unable to query database.</div>');
 		$this->printInstallForm();
 	}
 	
@@ -61,8 +58,33 @@ class install
 		return $this;
 	}
 	
+	public function configCheck()
+	{
+		// does a config exist?
+		if( is_file( LF.'config.php' ) )
+		{
+			include LF.'config.php'; // load $db config
+			notice('<div class="notice"><i class="fa fa-check"></i> Found config.php</div>');
+		}
+		else
+		{
+			notice('<div class="error">First time installation? Ignore this message. Otherwise: config.php not found.</div>');
+			(new install)->printInstallForm();
+		}
+		
+		return $this;
+	}
+	
 	public function printInstallForm()
 	{
+		$host = isset($_POST['host']) ? $_POST['host'] : 'localhost';
+		$user = isset($_POST['user']) ? $_POST['user'] : get_current_user();
+		$dbname = isset($_POST['dbname']) ? $_POST['dbname'] : get_current_user().'_lf';
+
+		// manage it within the call to install form.
+		if(count($_POST) > 0)
+			$this->post();
+
 		include LF.'system/lib/recovery/install.form.php';
 		return $this;
 	}
@@ -92,7 +114,8 @@ class install
 			$dbConfigFile = str_replace($variable, $value, $dbConfigFile);
 		}
 		
-		if(count($this->errors) > 0) return $this->printInstallForm();
+		if(count($this->errors) > 0) 
+			redirect302();//return $this->printInstallForm();
 		
 		// If the config.php is not already there, write it
 		if(!is_file(LF.'config.php') || (isset($_POST['overwrite']) && $_POST['overwrite'] == 'on'))

--- a/lf/system/lib/install.php
+++ b/lf/system/lib/install.php
@@ -12,7 +12,7 @@ if(!extension_loaded('mysqli'))
 /**
  * provide installform
  */
-class install
+class installOLD
 {
 	private $errors = array();
 	

--- a/lf/system/lib/orm.php
+++ b/lf/system/lib/orm.php
@@ -179,9 +179,6 @@ class orm implements \IteratorAggregate
 		// run through the checks of getting a usable mysqli instance
 		$this->verifyMysqli();
 		
-		// probably should have this. need to move to loading from config every time we need to run something that needs it...
-		$this->conf = $db; 
-		
 		// I think mysqli takes care of this
 		$this->query_count = 0; 
 		
@@ -236,6 +233,9 @@ class orm implements \IteratorAggregate
 			$this->error[] = '<div class="error"><i class="fa fa-exclamation-triangle"></i> Connection failed ('.$mysqli->connect_errno.'): '.$mysqli->connect_error.'</div>';
 			$this->runInstaller();
 		}
+		
+		// probably should have this. need to move to loading from config every time we need to run something that needs it...
+		$this->conf = $db; 
 		
 		// do we fail to select our database?
 		if( ! $mysqli->select_db( $this->conf['name']))

--- a/lf/system/lib/recovery/install.form.php
+++ b/lf/system/lib/recovery/install.form.php
@@ -35,6 +35,20 @@
 								<p><i class="fa fa-info-circle"></i> Enter your database credentials</p>
 								<ul class="vlist">
 									<li>
+										<?php if(is_file('config.php')): 
+											include 'config.php';
+											$host = $db['host'];
+											$user = $db['user'];
+											$dbname = $db['name'];
+											?>
+										<label for="">Overwrite Config File: <input class="check" type="checkbox" name="overwrite" checked="checked" /></label>
+										</li><li>
+										<label for="">Re-install Base Data: <input class="check" checked="checked" type="checkbox" name="data" /></label>
+										<?php else: ?>
+										<label for=""><input class="check" type="checkbox" name="data" checked="checked" /> Install Base Data (not needed if recovering a config)</label>
+										<?php endif; ?>
+									</li>
+									<li>
 										Host: <input type="text" value="<?=$host;?>" name="db[host]" value="localhost" />
 									</li>
 										Database Name: <input type="text" value="<?=$dbname;?>" name="db[dbname]" placeholder="eg. cpusername_littlefootdb" />
@@ -43,15 +57,6 @@
 									</li>
 									<li>
 										Password: <input type="password" name="db[pass]" placeholder="Database User's Password" />
-									</li>
-									<li>
-										<?php if(is_file('config.php')): ?>
-										<label for="">Overwrite Config File: <input class="check" type="checkbox" name="overwrite" checked="checked" /></label>
-										</li><li>
-										<label for="">Re-install Base Data: <input class="check" type="checkbox" name="data" /></label>
-										<?php else: ?>
-										<label for=""><input class="check" type="checkbox" name="data" checked="checked" /> Install Base Data (not needed if recovering a config)</label>
-										<?php endif; ?>
 									</li>
 								</ul>
 							</div>

--- a/lf/system/lib/recovery/install.form.php
+++ b/lf/system/lib/recovery/install.form.php
@@ -1,14 +1,10 @@
-<?php
-
-?>
 <html class="lf">
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link href="http://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">
-		<style type="text/css">
-			<?php readfile(ROOT.'system/lib/lf.css'); ?>
-		</style>
+		<link rel="stylesheet" href="<?=\lf\requestGet('LfUrl');?>system/lib/lf.css" />
+		<link rel="stylesheet" href="<?=\lf\requestGet('LfUrl');?>system/lib/3rdparty/icons.css" />
 	</head>
 	<body>
 		<h1 class="banner blue light text-center">Littlefoot Setup</h1>
@@ -18,7 +14,7 @@
 					<div class="col-3">
 					</div>
 					<div class="col-6">
-						<?=notice();?>					
+						<?=implode($this->error);?>					
 						<p>Enter your database credentials and preferred admin password, then click Install.</p>
 						<ul class="fvlist">
 							<li>

--- a/lf/system/lib/recovery/install.form.php
+++ b/lf/system/lib/recovery/install.form.php
@@ -7,16 +7,21 @@
 		<link rel="stylesheet" href="<?=\lf\requestGet('LfUrl');?>system/lib/3rdparty/icons.css" />
 	</head>
 	<body>
-		<h1 class="banner blue light text-center">Littlefoot Setup</h1>
+		<h1 class="banner blue light text-center">Setup</h1>
 		<div class="wide_container">
 			<form action="?" method="post">
 				<div class="row">
 					<div class="col-3">
 					</div>
 					<div class="col-6">
-						<?=implode($this->error);?>					
-						<h3>Help</h3>
-						<ul class="vlist">
+						<?php
+							$this->error[] = '';
+							echo implode($this->error);
+						?>					
+						<h3>What?</h3>
+						<p>Littlefoot uses an ORM to communicate with the database. It relies on a configuration file at <code><?=LF;?>config.php</code>. If this file is missing, or it does not have valid configuration information, this Setup page will pop up and allow you to set a new config. This is normal for new installations.</p>
+						<h4>Frequently Asked Questions</h4>
+						<ul class="efvlist">
 							<li>
 								How do I <a target="_blank" href="https://www.google.com/#q=how+to+create+user+and+database+in+mysql">create a user and database in mysql?</a>
 							</li>

--- a/lf/system/lib/recovery/install.form.php
+++ b/lf/system/lib/recovery/install.form.php
@@ -15,8 +15,8 @@
 					</div>
 					<div class="col-6">
 						<?=implode($this->error);?>					
-						<p>Enter your database credentials and preferred admin password, then click Install.</p>
-						<ul class="fvlist">
+						<h3>Help</h3>
+						<ul class="vlist">
 							<li>
 								How do I <a target="_blank" href="https://www.google.com/#q=how+to+create+user+and+database+in+mysql">create a user and database in mysql?</a>
 							</li>
@@ -24,19 +24,20 @@
 								How do I <a target="_blank" href="https://www.google.com/#q=how+to+create+user+and+database+in+mysql+cpanel">create a mysql user and database with cPanel?</a>
 							</li>
 						</ul>
-						<div class="row">
+						<div class="row no_martop">
 							<div class="col-6">
 								<h3>MySQL Access</h3>
+								<p><i class="fa fa-info-circle"></i> Enter your database credentials</p>
 								<ul class="vlist">
 									<li>
-										Host: <input type="text" value="<?=$host;?>" name="host" value="localhost" />
+										Host: <input type="text" value="<?=$host;?>" name="db[host]" value="localhost" />
 									</li>
-										Database Name: <input type="text" value="<?=$dbname;?>" name="dbname" placeholder="eg. cpusername_littlefootdb" />
+										Database Name: <input type="text" value="<?=$dbname;?>" name="db[dbname]" placeholder="eg. cpusername_littlefootdb" />
 									<li>
-										Database User: <input type="text" value="<?=$user;?>"name="user" placeholder="eg. cpusername_dbuser" />
+										Database User: <input type="text" value="<?=$user;?>"name="db[user]" placeholder="eg. cpusername_dbuser" />
 									</li>
 									<li>
-										Password: <input type="password" name="pass" placeholder="Database User's Password" />
+										Password: <input type="password" name="db[pass]" placeholder="Database User's Password" />
 									</li>
 									<li>
 										<?php if(is_file('config.php')): ?>
@@ -48,29 +49,25 @@
 										<?php endif; ?>
 									</li>
 								</ul>
-								
-										
-										
-										
-										
-										
 							</div>
 							<div class="col-6">
 								<h3>Site Admin User</h3>
+								<p><i class="fa fa-info-circle"></i> and preferred admin password,</p>
 								<ul class="vlist">
 									<li>
 										<label for="auser">Username</label>
-										<input type="text" name="auser" id="auser" value="admin" required/>
+										<input type="text" name="admin[user]" id="auser" value="admin" required/>
 									</li>
+									<li>
 										<label for="apass">Password</label>
-										<input type="password" name="apass" id="apass" placeholder="Sup3rSecr3tP@$$word" required/>
-									<li>
+										<input type="password" name="admin[pass]" id="apass" placeholder="Sup3rSecr3tP@$$word" required/>
 									</li>
 									<li>
+										<p><i class="fa fa-info-circle"></i> then click Install.</p>
 										<button class="green" style="">Install</button>
 									</li>
 									<li>
-										<a class="blue button marbot" target="_blank" href="http://littlefootcms.com/">View User Guide</a>
+										<a class="blue button marbot" target="_blank" href="http://littlefootcms.com/manual">View Littlefoot Manual</a>
 									</li>
 								</ul>
 							</div>

--- a/lf/system/lib/recovery/install.form.php
+++ b/lf/system/lib/recovery/install.form.php
@@ -1,43 +1,5 @@
 <?php
 
-//check for crucial php settings
-if(version_compare(phpversion(), '5.4.0', '<')
-&& get_magic_quotes_gpc()) // magic quotes (only affects <5.4)
-        $warnings[] = '[<a target="_blank" href="https://www.google.com/search?q=how+to+disable+magic+quotes">Fix it</a>] Magic quotes is ENABLED';
-
-if(version_compare(phpversion(), '5.4.0', '<')
-&& ini_get('short_open_tag') == false) // php short tags (only affects <5.4)
-        $warnings[] = '[<a target="_blank" href="https://www.google.com/search?q=how+to+enable+php+short+tags">Fix it</a>] Short tags is DISABLED ';
-
-if(is_file('config.php'))
-{
-	//include 'config.php';
-	$dbconn = (new \lf\orm)->initDb();
-	
-	if($dbconn->error != '') $errors = $dbconn->error;
-	else
-	{
-		if(!$dbconn->fetch("select * from lf_settings limit 1"))
-			$msg .= 'I found a config file, but can\'t seem to connect to your database. Please verify the contents of lf/config.php or try and reconfigure the credentials.';
-		else
-			$msg .= 'The config file exists, but the database seems to be missing crucial data in at least lf_settings.';
-	}
-}
-
-$host = isset($_POST['host']) ? $_POST['host'] : 'localhost';
-$user = isset($_POST['user']) ? $_POST['user'] : get_current_user();
-$dbname = isset($_POST['dbname']) ? $_POST['dbname'] : get_current_user().'_lf';
-
-if(isset($msg))
-	$msg = '<div class="warning marbot rounded">'.$msg.'</div>';
-else
-	$msg = '';
-
-$error_msg = '';
-if(count($this->errors) > 0)
-	foreach($this->errors as $error)
-		$error_msg .= '<div class="marbot error rounded">'.$error.'</div>';
-
 ?>
 <html class="lf">
 	<head>
@@ -49,15 +11,14 @@ if(count($this->errors) > 0)
 		</style>
 	</head>
 	<body>
-		<h1 class="banner dark_gray light text-center">Littlefoot Setup</h1>
+		<h1 class="banner blue light text-center">Littlefoot Setup</h1>
 		<div class="wide_container">
 			<form action="?" method="post">
 				<div class="row">
 					<div class="col-3">
 					</div>
 					<div class="col-6">
-						<?=isset($msg) ? $msg : '';?>
-						<?=isset($error_msg) ? $error_msg : '';?>					
+						<?=notice();?>					
 						<p>Enter your database credentials and preferred admin password, then click Install.</p>
 						<ul class="fvlist">
 							<li>
@@ -83,11 +44,11 @@ if(count($this->errors) > 0)
 									</li>
 									<li>
 										<?php if(is_file('config.php')): ?>
-										<label for="">Overwrite Config File:</label> <input class="check" type="checkbox" name="overwrite" checked="checked" />
-										
-										<label for="">Re-install Base Data:</label> <input class="check" type="checkbox" name="data" />
+										<label for="">Overwrite Config File: <input class="check" type="checkbox" name="overwrite" checked="checked" /></label>
+										</li><li>
+										<label for="">Re-install Base Data: <input class="check" type="checkbox" name="data" /></label>
 										<?php else: ?>
-										<label for=""><input class="check" type="checkbox" name="data" checked="checked" /> Install Base Data (uncheck this if you are just remaking a lost config)</label>
+										<label for=""><input class="check" type="checkbox" name="data" checked="checked" /> Install Base Data (not needed if recovering a config)</label>
 										<?php endif; ?>
 									</li>
 								</ul>

--- a/lf/system/lib/request.php
+++ b/lf/system/lib/request.php
@@ -45,6 +45,19 @@ class request
 		'action' => []
 	];
 	
+	public function rewriteOn()
+	{
+		$this->pieces['index'] = '';
+		return $this;
+	}
+	
+	public function rewriteOff()
+	{
+		$this->pieces['index'] = 'index.php/';
+		return $this;
+	}
+	
+	
 	/** Parse REQUEST_URI into `$pieces` */
 	public function parse($uri = null)
 	{
@@ -109,23 +122,6 @@ class request
 			// Set first action as alias '' (empty string)
 			$action[] = '';
 		
-		// Add in 302 to fix rewrite and prevent duplicate content
-		$fixrewrite = false;
-		if(getSetting('rewrite') == 'on')
-		{
-			if($index == 'index.php/') 
-				$fixrewrite = true;
-			
-			$index = '';
-		}
-		else
-		{
-			if($index == '') 
-				$fixrewrite = true;
-			
-			$index = $filename.'/';
-		}
-		
 		// set port if non-standard 80 and 443
 		if($_SERVER['SERVER_PORT'] != 80 && $_SERVER['SERVER_PORT'] != 443)
 			$port = ':'.$_SERVER['SERVER_PORT']; 
@@ -154,10 +150,6 @@ class request
 			'get'		=> $_GET,
 			'post'		=> $_POST
 		];
-		
-		// If rewrite needed fixed, this will redirect and keep the URL intact.
-		if($fixrewrite) 
-			redirect302( $this->getActionUrl() );
 		
 		//$this->hook_run('post lf request');
 		
@@ -255,7 +247,6 @@ class request
 	 */
 	public function getLfUrl()
 	{
-		extract($this->pieces);
 		return $this->getSubdirUrl().'lf/';
 	}
 	


### PR DESCRIPTION
Installer brought into 2.0
- Fixed: If you typed in the wrong mysql credentials, the resulting config.php would error.
  - Now handled gracefully.
- Moved whole installer system into `\lf\orm` methods
  - Not 100% on this, but it seems stable and its all private within the ORM class, so I can always change this easily due to the low dependence.
- More help text added. If you ever have any questions, submit an issue in this github!
